### PR TITLE
新增关联结果判断，为空删除分组。

### DIFF
--- a/src/model/LinGroup.php
+++ b/src/model/LinGroup.php
@@ -92,6 +92,14 @@ class LinGroup extends Model
     public static function deleteGroupAuth($id)
     {
         $user = self::get($id,'auth');
+
+        if (!$user){
+            throw new GroupException([
+                'error_code' => 30006,
+                'msg' => '分组删除失败'
+            ]);
+        }
+
         $deleteGroup = $user->together('auth')->delete();
         if(!$deleteGroup)
         {

--- a/src/model/LinGroup.php
+++ b/src/model/LinGroup.php
@@ -94,13 +94,11 @@ class LinGroup extends Model
         $user = self::get($id,'auth');
 
         if (!$user){
-            throw new GroupException([
-                'error_code' => 30006,
-                'msg' => '分组删除失败'
-            ]);
+            $deleteGroup = self::destroy($id);
+        }else{
+            $deleteGroup = $user->together('auth')->delete();
         }
 
-        $deleteGroup = $user->together('auth')->delete();
         if(!$deleteGroup)
         {
             throw new GroupException([


### PR DESCRIPTION
## 在删除分组时

### 如果条件关联失败

原因： 结果为空，会抛出框架函数错误

原代码：

```php
/**
     * @param $id
     * @return mixed
     */
    public static function deleteGroupAuth($id)
    {
        $user = self::get($id,'auth');
        $deleteGroup = $user->together('auth')->delete();
        if(!$deleteGroup)
        {
            throw new GroupException([
                'error_code' => 30005,
                'msg' => '分组删除失败'
            ]);
        }
        return $deleteGroup;

    }
```

解决： 为空时直接删除分组，不再关联删除。

优化结果如下：

```php

/**
     * @param $id
     * @return mixed
     */
    public static function deleteGroupAuth($id)
    {
        $user = self::get($id,'auth');

        if (!$user){
            $deleteGroup = self::destroy($id);
        }else{
            $deleteGroup = $user->together('auth')->delete();
        }

        if(!$deleteGroup)
        {
            throw new GroupException([
                'error_code' => 30005,
                'msg' => '分组删除失败'
            ]);
        }
        return $deleteGroup;

    }
```
